### PR TITLE
1.0.0a3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   name        = 'PyOTA-CCurl',
   description = 'C Curl extension for PyOTA',
   url         = 'https://github.com/todofixthis/pyota-ccurl',
-  version     = '1.0.0a2',
+  version     = '1.0.0a3',
 
   long_description = long_description,
 


### PR DESCRIPTION
# PyOTA-CCurl v1.0.0a3
* Fixed behavior of `Curl_squeeze` when `incoming` is too small.

⚠️ **THIS VERSION IS EXPERIMENTAL AND HAS NOT BEEN VETTED FOR STABILITY/SECURITY YET; DO NOT USE IN PRODUCTION CODE!!!** ⚠️ 