### PR TITLE
1.0.0a4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ C Curl Extension for PyOTA
 .. DANGER::
    ⚠️ **THIS VERSION IS EXPERIMENTAL AND HAS NOT BEEN VETTED FOR STABILITY/SECURITY YET; DO NOT USE IN PRODUCTION CODE!!!** ⚠️
 
-This is an extension for the crypto functionality in `PyOTA`_, the Python API
+This is an extension for the crypto functionality in `PyOTA <https://pypi.python.org/pypi/PyOTA>`_, the Python API
 for IOTA.  When installed, it will significantly boost the performance of
 PyOTA's crypto functionality.
 
@@ -13,6 +13,29 @@ This extension is installed as an add-on to the ``pyota`` package::
 
 Compatibility
 -------------
-This extension is currently compatible with Python 3 only.  A Python-2-compatible version is in the works though!
+This extension is currently compatible with Python 3.6 and 3.5 only.
 
-.. _PyOTA: https://pypi.python.org/pypi/PyOTA
+`I've documented the issues with the Python 2 C API <https://github.com/todofixthis/pyota-ccurl/issues/4>`_.
+Adding Python 2 support is on my list, but it may take me a bit before I can get to it.
+
+If you have experience with C and are interested in getting involved,
+please reach out to me on the `IOTA Slack network <https://iotatangle.slack.com/>`_ or submit a pull request.
+
+Testing
+-------
+The easiest way to test the extension is to install it and then run the PyOTA unit tests.
+
+Here's a modified ``tox.ini`` file that for PyOTA that will install the C extension before running unit tests::
+
+   [tox]
+   envlist = py27, py35, py36
+
+   [testenv]
+   commands =
+     pip install --pre pyota-ccurl
+     nosetests
+   deps =
+     mock
+     nose
+
+Note that this file needs to be installed in the PyOTA codebase!

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 C Curl Extension for PyOTA
 ==========================
 .. DANGER::
-   ⚠️ **THIS VERSION IS EXPERIMENTAL AND HAS NOT BEEN VETTED FOR STABILITY/SECURITY YET; DO NOT USE IN PRODUCTION CODE!!!** ⚠️ 
+   ⚠️ **THIS VERSION IS EXPERIMENTAL AND HAS NOT BEEN VETTED FOR STABILITY/SECURITY YET; DO NOT USE IN PRODUCTION CODE!!!** ⚠️
 
 This is an extension for the crypto functionality in `PyOTA`_, the Python API
 for IOTA.  When installed, it will significantly boost the performance of
@@ -10,5 +10,9 @@ PyOTA's crypto functionality.
 This extension is installed as an add-on to the ``pyota`` package::
 
    pip install pyota[ccurl]
+
+Compatibility
+-------------
+This extension is currently compatible with Python 3 only.  A Python-2-compatible version is in the works though!
 
 .. _PyOTA: https://pypi.python.org/pypi/PyOTA

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   name        = 'PyOTA-CCurl',
   description = 'C Curl extension for PyOTA',
   url         = 'https://github.com/todofixthis/pyota-ccurl',
-  version     = '1.0.0a3',
+  version     = '1.0.0a4',
 
   long_description = long_description,
 

--- a/src/ccurlmodule.c
+++ b/src/ccurlmodule.c
@@ -40,13 +40,12 @@ _Curl_transform(Curl *self)
 {
   // Adapted from https://github.com/iotaledger/ccurl/blob/master/src/lib/Curl.c
   trit_t scratchpad[STATE_LENGTH];
-  int scratchpadIndex = 0;
-  int scratchpadIndexSave;
+  int round, scratchpadIndex=0, scratchpadIndexSave, stateIndex;
 
-  for (int round = 0; round < NUMBER_OF_ROUNDS; round++) {
+  for (round = 0; round < NUMBER_OF_ROUNDS; round++) {
     memcpy(scratchpad, self->_state, STATE_LENGTH * sizeof(trit_t));
 
-    for (int stateIndex = 0; stateIndex < STATE_LENGTH; stateIndex++) {
+    for (stateIndex = 0; stateIndex < STATE_LENGTH; stateIndex++) {
       scratchpadIndexSave = scratchpadIndex;
       scratchpadIndex += (scratchpadIndex < 365 ? 364 : -365);
       self->_state[stateIndex] = TRUTH_TABLE[scratchpad[scratchpadIndexSave ] + scratchpad[scratchpadIndex ] * 3 + 4];
@@ -111,7 +110,7 @@ static PyObject*
 Curl_squeeze(Curl *self, PyObject *args, PyObject *kwds)
 {
   PyObject *incoming;
-  int incoming_count;
+  int i, incoming_count;
 
   static char *kwlist[] = {"trits", NULL};
 
@@ -135,7 +134,7 @@ Curl_squeeze(Curl *self, PyObject *args, PyObject *kwds)
   // Can't use ``memcpy`` here because we have to convert ints into ``PyLongObject``.
   // This isn't the slow part of Curl (that honor is reserved for ``_Curl_transform``),
   // so it shouldn't be that big of a problem.
-  for (int i=0; i < HASH_LENGTH; i++) {
+  for (i=0; i < HASH_LENGTH; i++) {
     PyList_SetItem(incoming, i, PyLong_FromLong(self->_state[i]));
   }
 

--- a/src/ccurlmodule.c
+++ b/src/ccurlmodule.c
@@ -81,13 +81,13 @@ Curl_absorb(Curl *self, PyObject *args, PyObject *kwds)
     incoming_item = PyList_GetItem(incoming, i);
 
     if ((incoming_item == NULL) || ! PyLong_Check(incoming_item)) {
-      PyErr_SetString(PyExc_ValueError, "`trits` argument contains non-numeric values.");
+      PyErr_Format(PyExc_ValueError, "`trits` argument contains non-numeric value at index %u.", i);
       return NULL;
     }
 
     incoming_value = (trit_t)PyLong_AsLong(incoming_item);
     if ((incoming_value < -1) || (incoming_value > 1)) {
-      PyErr_SetString(PyExc_ValueError, "`trits` argument contains values outside range [-1, 1].");
+      PyErr_Format(PyExc_ValueError, "`trits` argument contains value outside range [-1, 1] at index %u.", i);
       return NULL;
     }
 


### PR DESCRIPTION
# PyOTA-CCurl v1.0.0a4
- Fixed warnings due to implicit variable initialization.
- `absorb` now includes the index of the invalid value in exception messages.

⚠️ **THIS VERSION IS EXPERIMENTAL AND HAS NOT BEEN VETTED FOR STABILITY/SECURITY YET; DO NOT USE IN PRODUCTION CODE!!!** ⚠️ 