### PR TITLE
Fix memory leak in Curl_absorb

### DIFF
--- a/src/ccurlmodule.c
+++ b/src/ccurlmodule.c
@@ -103,6 +103,8 @@ Curl_absorb(Curl *self, PyObject *args, PyObject *kwds)
     offset += HASH_LENGTH;
   } while ((incoming_count -= HASH_LENGTH) > 0);
 
+  free(trits);
+
   Py_INCREF(Py_None);
   return Py_None;
 }


### PR DESCRIPTION
Curl_absorb did a malloc() for storing the trit_t representation of
the incoming trits but the memory was never free()'d which results in
a memory leak.