### PR TITLE
1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,14 @@ python:
 install: pip install .
 script:
   - pip install nose mock
-  - 'if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then mkdir pyota-unittests && pip install --no-deps --no-use-wheel --download pyota-unittests --pre pyota; fi'
-  - 'if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip download --no-deps --no-binary :all: --dest pyota-unittests --pre pyota; fi'
+  - 'pip download --no-deps --no-binary :all: --dest pyota-unittests --pre pyota'
   - tar -zxf pyota-unittests/PyOTA-*.tar.gz -C pyota-unittests --strip-components=1
   - nosetests pyota-unittests/test
 deploy:
   on:
     branch: master
   provider: pypi
-  distribution: sdist bdist_wheel
+  distribution: bdist_wheel sdist
   skip_upload_docs: true
   user: phx
   password:

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,7 @@ This extension is installed as an add-on to the ``pyota`` package::
 
 Compatibility
 -------------
-This extension is currently compatible with Python 3.6 and 3.5 only.
-
-`I've documented the issues with the Python 2 C API <https://github.com/todofixthis/pyota-ccurl/issues/4>`_.
-Adding Python 2 support is on my list, but it may take me a bit before I can get to it.
-
-If you have experience with C and are interested in getting involved,
-please reach out to me on the `IOTA Slack network <https://slack.iota.org/>`_ or submit a pull request.
+This extension is compatible with Python 3.6, 3.5 and 2.7.
 
 Testing
 -------

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   name        = 'PyOTA-CCurl',
   description = 'C Curl extension for PyOTA',
   url         = 'https://github.com/todofixthis/pyota-ccurl',
-  version     = '1.0.2',
+  version     = '1.0.3',
 
   long_description = long_description,
 


### PR DESCRIPTION
# PyOTA-CCurl v1.0.3
* [#4] Now compiles against Python 2.7 (thanks @etiennekruger!)
* Fixed a memory leak (thanks @etiennekruger!).
* Upgraded Travis CI configuration to use new Trusty images.
