### PR TITLE
Release/1.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ script:
 deploy:
   on:
     tags: true
+    python: '3.6'
   provider: pypi
-  distributions: 'bdist_wheel sdist'
+  distributions: sdist
   skip_upload_docs: true
   user: phx
   password:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   name        = 'PyOTA-CCurl',
   description = 'C Curl extension for PyOTA',
   url         = 'https://github.com/todofixthis/pyota-ccurl',
-  version     = '1.0.4',
+  version     = '1.0.5',
 
   long_description = long_description,
 


### PR DESCRIPTION
# PyOTA-CCurl v1.0.5
* Removed wheel distributions from Travis CI configuration.
    * PyPI doesn't support the "linux_x86_64" platform tag.