### PR TITLE
Release/1.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,19 @@ script:
   - tar -zxf pyota-unittests/PyOTA-*.tar.gz -C pyota-unittests --strip-components=1
   - nosetests pyota-unittests/test
 deploy:
-  on:
-    tags: true
-    python: '3.6'
-  provider: pypi
-  distributions: sdist
-  skip_upload_docs: true
-  user: phx
-  password:
-    secure: uprcy4uI8nx4t6NVfyzAlr5L9JgomGg6ZJbhb0u7lRUuOHeCB9ETXrg6zSbwiBGKc3bnbnAIJvGGVJErAdsOd9x5p3oyZI8UPOj9nQCKX3FStIl0x10licad1X5lO2WlIGyJNlg+uncFr3sUCG4W4SqujmDsBQnsUBVG2ei0i9eLxxzQsp+gPPPlVw2OLlkJ40B6wO64XcIf6Zlzq4Z/7mvtH3fkczPBiS6UYEv1I1OEBUaZ/h1fsvsbnriMV3Li3hdt22kquEqSxwxBjMcJ9FRAuyhJZz/GNkeHLiLkDodR3VKHan5+jBsWH44+xriOxNVhGNdI84u0NmXz00Crs5WL7O83vjM8m1t3rK1uX+fiyG7WhClFov1Lk4/OqBBUg92rXKvj1h78tSW2ldlwN6pv2QrmpZtWLDZySSPPmkDKAEQoWBo6wuotltqO9EUwi8Y4MHaXafRJcT5OaqJLa12jJTWAyAauzrO7HbcrCLJetcb1KY+ouBw7agLw30juPgm3d35mNV2jWaU2FaYr/vTGuT/PLQMOgWWoGb0LzHcLhrrv7QIBM/LZX+an02DGNHRoV7qGF5w+OLAt8eZOMuAhesZ5HTOXWj5+IXGjAupaJ/9cOYnSM7OwUjXcOh7I/5dvx41wV6sxDuI0jiIqCN47ZpSyA33FnCpjfrs6wTM=
+  - on:
+      tags: true
+      python: '3.6'
+    provider: pypi
+    distributions: 'bdist_wheel sdist'
+    user: phx
+    password:
+      secure: uprcy4uI8nx4t6NVfyzAlr5L9JgomGg6ZJbhb0u7lRUuOHeCB9ETXrg6zSbwiBGKc3bnbnAIJvGGVJErAdsOd9x5p3oyZI8UPOj9nQCKX3FStIl0x10licad1X5lO2WlIGyJNlg+uncFr3sUCG4W4SqujmDsBQnsUBVG2ei0i9eLxxzQsp+gPPPlVw2OLlkJ40B6wO64XcIf6Zlzq4Z/7mvtH3fkczPBiS6UYEv1I1OEBUaZ/h1fsvsbnriMV3Li3hdt22kquEqSxwxBjMcJ9FRAuyhJZz/GNkeHLiLkDodR3VKHan5+jBsWH44+xriOxNVhGNdI84u0NmXz00Crs5WL7O83vjM8m1t3rK1uX+fiyG7WhClFov1Lk4/OqBBUg92rXKvj1h78tSW2ldlwN6pv2QrmpZtWLDZySSPPmkDKAEQoWBo6wuotltqO9EUwi8Y4MHaXafRJcT5OaqJLa12jJTWAyAauzrO7HbcrCLJetcb1KY+ouBw7agLw30juPgm3d35mNV2jWaU2FaYr/vTGuT/PLQMOgWWoGb0LzHcLhrrv7QIBM/LZX+an02DGNHRoV7qGF5w+OLAt8eZOMuAhesZ5HTOXWj5+IXGjAupaJ/9cOYnSM7OwUjXcOh7I/5dvx41wV6sxDuI0jiIqCN47ZpSyA33FnCpjfrs6wTM=
+  - on:
+      tags: true
+      python: '2.7'
+    provider: pypi
+    distributions: 'bdist_wheel'
+    user: phx
+    password:
+      secure: uprcy4uI8nx4t6NVfyzAlr5L9JgomGg6ZJbhb0u7lRUuOHeCB9ETXrg6zSbwiBGKc3bnbnAIJvGGVJErAdsOd9x5p3oyZI8UPOj9nQCKX3FStIl0x10licad1X5lO2WlIGyJNlg+uncFr3sUCG4W4SqujmDsBQnsUBVG2ei0i9eLxxzQsp+gPPPlVw2OLlkJ40B6wO64XcIf6Zlzq4Z/7mvtH3fkczPBiS6UYEv1I1OEBUaZ/h1fsvsbnriMV3Li3hdt22kquEqSxwxBjMcJ9FRAuyhJZz/GNkeHLiLkDodR3VKHan5+jBsWH44+xriOxNVhGNdI84u0NmXz00Crs5WL7O83vjM8m1t3rK1uX+fiyG7WhClFov1Lk4/OqBBUg92rXKvj1h78tSW2ldlwN6pv2QrmpZtWLDZySSPPmkDKAEQoWBo6wuotltqO9EUwi8Y4MHaXafRJcT5OaqJLa12jJTWAyAauzrO7HbcrCLJetcb1KY+ouBw7agLw30juPgm3d35mNV2jWaU2FaYr/vTGuT/PLQMOgWWoGb0LzHcLhrrv7QIBM/LZX+an02DGNHRoV7qGF5w+OLAt8eZOMuAhesZ5HTOXWj5+IXGjAupaJ/9cOYnSM7OwUjXcOh7I/5dvx41wV6sxDuI0jiIqCN47ZpSyA33FnCpjfrs6wTM=

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This extension is installed as an add-on to the ``pyota`` package::
    pip install pyota[ccurl]
 
 After running the above command, you can verify that the C extension is
-installed correctly by running the ``check_ccurl`` command::
+installed correctly by running the ``check_ccurl`` command in your shell::
 
    > check_ccurl
    😸  CCurl is installed correctly!

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,14 @@ This extension is installed as an add-on to the ``pyota`` package::
 
    pip install pyota[ccurl]
 
+After running the above command, you can verify that the C extension is
+installed correctly by running the ``check_ccurl`` command::
+
+   > check_ccurl
+   😸  CCurl is installed correctly!
+   For support, visit the #iota-libs-pyota channel on the IOTA Slack.
+   https://slack.iota.org/
+
 Compatibility
 -------------
 This extension is compatible with Python 3.6, 3.5 and 2.7.

--- a/pyota_ccurl/__init__.py
+++ b/pyota_ccurl/__init__.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+
+def is_installed():
+  # type: () -> bool
+  """
+  Returns whether the C extension is installed correctly.
+  """
+  try:
+    # noinspection PyUnresolvedReferences
+    from ccurl import Curl as CCurl
+  except ImportError:
+    return False
+  else:
+    # noinspection PyUnresolvedReferences
+    from iota.crypto import Curl
+    return issubclass(Curl, CCurl)
+
+
+def check_installation():
+  """
+  Outputs a message indicating whether the C extension is installed
+  correctly.
+  """
+  print(
+    '😸  CCurl is installed correctly!'
+      if is_installed()
+      else '😿  CCurl is NOT installed correctly!'
+  )
+  print('For support, visit the #iota-libs-pyota channel on the IOTA Slack.')
+  print('https://slack.iota.org/')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   name        = 'PyOTA-CCurl',
   description = 'C Curl extension for PyOTA',
   url         = 'https://github.com/todofixthis/pyota-ccurl',
-  version     = '1.0.5',
+  version     = '1.0.6',
 
   long_description = long_description,
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,14 @@ setup(
 
   long_description = long_description,
 
+  packages = ['pyota_ccurl'],
   ext_modules = [Extension('ccurl', ['src/ccurlmodule.c'])],
+
+  entry_points = {
+    'console_scripts': [
+      'check_ccurl = pyota_ccurl:check_installation',
+    ],
+  },
 
   install_requires = ['pyota'],
 


### PR DESCRIPTION
# PyOTA-CCurl v1.0.6
* [#16] Added `pyota_ccurl` module with utility functions to check that the C extension is installed correctly.
* Possible workaround for issue preventing Travis CI from publishing wheels to PyPI.